### PR TITLE
Centralize credential retrieval

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
+
+	"github.com/pmaojo/n8n-ops/internal/credentials"
 
 	"github.com/pmaojo/n8n-ops/internal/client"
 	"github.com/sirupsen/logrus"
@@ -136,7 +137,14 @@ func serveDashboard(w http.ResponseWriter, r *http.Request) {
 
 	data := DashboardData{
 		Environment: environment,
-		N8nURL:      getN8nURL(),
+		N8nURL: func() string {
+			cm := credentials.NewCredentialManager(environment)
+			url, _, _ := cm.GetN8nCredentials()
+			if url == "" {
+				return "http://localhost:5678"
+			}
+			return url
+		}(),
 		SystemStatus: map[string]string{
 			"CLI":     "ONLINE",
 			"DAEMON":  "ACTIVE",
@@ -166,16 +174,23 @@ func serveDashboard(w http.ResponseWriter, r *http.Request) {
 
 func serveAPIData(w http.ResponseWriter, r *http.Request) {
 	// Connect to n8n to get real data
-	var n8nURL string
+	var n8nURL, apiKey string
 	if demoMode {
 		n8nURL = "http://localhost:3001"
+		apiKey = "n8n_api_mock_development"
 	} else {
-		n8nURL = getN8nURL()
-	}
-
-	apiKey := "n8n_api_mock_development"
-	if !demoMode {
-		apiKey = os.Getenv("N8N_API_KEY")
+		cm := credentials.NewCredentialManager(environment)
+		var err error
+		n8nURL, apiKey, err = cm.GetN8nCredentials()
+		if err != nil {
+			logger.Warn("failed to load credentials, using demo data")
+		}
+		if n8nURL == "" {
+			n8nURL = "http://localhost:5678"
+		}
+		if apiKey == "" {
+			apiKey = "n8n_api_mock_development"
+		}
 	}
 
 	// Try to get real data
@@ -201,17 +216,4 @@ func serveAPIData(w http.ResponseWriter, r *http.Request) {
                 "timestamp": "%s",
                 "environment": "%s"
         }`, time.Now().Format("15:04:05"), environment)
-}
-
-func getN8nURL() string {
-	switch environment {
-	case "development":
-		return "http://localhost:5678"
-	case "staging":
-		return "https://n8n-staging.example.com"
-	case "production":
-		return "https://n8n-prod.example.com"
-	default:
-		return "http://localhost:5678"
-	}
 }

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pmaojo/n8n-ops/internal/credentials"
+
 	"github.com/pmaojo/n8n-ops/internal/client"
 	"github.com/pmaojo/n8n-ops/internal/issues"
 	"github.com/pmaojo/n8n-ops/internal/monitoring"
@@ -79,44 +81,11 @@ func runMonitor(cmd *cobra.Command, args []string) error {
 		n8nURL = "http://localhost:3001"
 		apiKey = "n8n_api_mock_development"
 	} else {
-		// Get credentials using cascading environment variable approach
-		envSuffix := strings.ToUpper(environment)
-		n8nURL = os.Getenv(fmt.Sprintf("N8N_%s_URL", envSuffix))
-		apiKey = os.Getenv(fmt.Sprintf("N8N_%s_API_KEY", envSuffix))
-
-		// Fallback to short forms for common environments
-		if n8nURL == "" || apiKey == "" {
-			switch environment {
-			case "development":
-				if n8nURL == "" {
-					n8nURL = os.Getenv("N8N_DEV_URL")
-				}
-				if apiKey == "" {
-					apiKey = os.Getenv("N8N_DEV_API_KEY")
-				}
-			case "staging":
-				if n8nURL == "" {
-					n8nURL = os.Getenv("N8N_STAGING_URL")
-				}
-				if apiKey == "" {
-					apiKey = os.Getenv("N8N_STAGING_API_KEY")
-				}
-			case "production":
-				if n8nURL == "" {
-					n8nURL = os.Getenv("N8N_PROD_URL")
-				}
-				if apiKey == "" {
-					apiKey = os.Getenv("N8N_PROD_API_KEY")
-				}
-			}
-		}
-
-		// Final fallback to generic variables
-		if n8nURL == "" {
-			n8nURL = os.Getenv("N8N_URL")
-		}
-		if apiKey == "" {
-			apiKey = os.Getenv("N8N_API_KEY")
+		cm := credentials.NewCredentialManager(environment)
+		var err error
+		n8nURL, apiKey, err = cm.GetN8nCredentials()
+		if err != nil {
+			return fmt.Errorf("failed to load credentials: %w", err)
 		}
 		if n8nURL == "" || apiKey == "" {
 			return fmt.Errorf("n8n credentials not configured for %s environment. Set N8N_%s_URL and N8N_%s_API_KEY or use --demo",

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pmaojo/n8n-ops/internal/credentials"
+
 	"github.com/pmaojo/n8n-ops/internal/git"
 	"github.com/spf13/cobra"
 )
@@ -178,8 +180,8 @@ func runStatusHuman() error {
 	fmt.Printf("\n🌍 Environment Status\n")
 	fmt.Printf("===================\n")
 
-	n8nURL := os.Getenv(fmt.Sprintf("N8N_URL_%s", strings.ToUpper(environment)))
-	n8nAPIKey := os.Getenv(fmt.Sprintf("N8N_API_KEY_%s", strings.ToUpper(environment)))
+	cm := credentials.NewCredentialManager(environment)
+	n8nURL, n8nAPIKey, _ := cm.GetN8nCredentials()
 
 	if n8nURL != "" {
 		fmt.Printf("N8N URL:    %s\n", n8nURL)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pmaojo/n8n-ops/internal/credentials"
+
 	"github.com/pmaojo/n8n-ops/internal/client"
 	"github.com/pmaojo/n8n-ops/internal/git"
 	"github.com/spf13/cobra"
@@ -89,47 +91,14 @@ func runSync(cmd *cobra.Command, args []string) error {
 		apiURL = "demo://localhost"
 		apiKey = "demo-key"
 	} else {
-		// Get credentials using cascading environment variable approach
-		envSuffix := strings.ToUpper(environment)
-		apiURL = os.Getenv(fmt.Sprintf("N8N_%s_URL", envSuffix))
-		apiKey = os.Getenv(fmt.Sprintf("N8N_%s_API_KEY", envSuffix))
-
-		// Fallback to short forms for common environments
+		cm := credentials.NewCredentialManager(environment)
+		var err error
+		apiURL, apiKey, err = cm.GetN8nCredentials()
+		if err != nil {
+			return fmt.Errorf("failed to load credentials: %w", err)
+		}
 		if apiURL == "" || apiKey == "" {
-			switch environment {
-			case "development":
-				if apiURL == "" {
-					apiURL = os.Getenv("N8N_DEV_URL")
-				}
-				if apiKey == "" {
-					apiKey = os.Getenv("N8N_DEV_API_KEY")
-				}
-			case "staging":
-				if apiURL == "" {
-					apiURL = os.Getenv("N8N_STAGING_URL")
-				}
-				if apiKey == "" {
-					apiKey = os.Getenv("N8N_STAGING_API_KEY")
-				}
-			case "production":
-				if apiURL == "" {
-					apiURL = os.Getenv("N8N_PROD_URL")
-				}
-				if apiKey == "" {
-					apiKey = os.Getenv("N8N_PROD_API_KEY")
-				}
-			}
-		}
-
-		// Final fallback to generic variables
-		if apiURL == "" {
-			apiURL = os.Getenv("N8N_URL")
-		}
-		if apiKey == "" {
-			apiKey = os.Getenv("N8N_API_KEY")
-		}
-
-		if apiURL == "" || apiKey == "" {
+			envSuffix := strings.ToUpper(environment)
 			fmt.Printf("⚠️  n8n credentials not configured for %s environment\n", environment)
 			fmt.Printf("💡 Set environment variables or use --demo flag:\n")
 			fmt.Printf("   export N8N_%s_URL=http://localhost:3001\n", envSuffix)

--- a/cmd/terminal_dashboard.go
+++ b/cmd/terminal_dashboard.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pmaojo/n8n-ops/internal/credentials"
+
 	"github.com/pmaojo/n8n-ops/internal/client"
 	"github.com/pmaojo/n8n-ops/internal/utils"
 	"github.com/sirupsen/logrus"
@@ -52,18 +54,22 @@ func runTerminalDashboard(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	// Connect to n8n client
-	var n8nURL string
+	var n8nURL, apiKey string
 	if demoMode {
 		n8nURL = "http://localhost:3001"
+		apiKey = "n8n_api_mock_development"
 	} else {
-		n8nURL = getN8nURLForDashboard()
-	}
-
-	apiKey := "n8n_api_mock_development"
-	if !demoMode {
-		apiKey = os.Getenv("N8N_API_KEY")
+		cm := credentials.NewCredentialManager(environment)
+		var err error
+		n8nURL, apiKey, err = cm.GetN8nCredentials()
+		if err != nil {
+			return fmt.Errorf("failed to load credentials: %w", err)
+		}
+		if n8nURL == "" {
+			n8nURL = "http://localhost:5678"
+		}
 		if apiKey == "" {
-			return fmt.Errorf("N8N_API_KEY environment variable is required")
+			return fmt.Errorf("N8N_%s_API_KEY environment variable is required", strings.ToUpper(environment))
 		}
 	}
 
@@ -246,18 +252,5 @@ func getStatusColor(status string) string {
 		return "yellow"
 	default:
 		return "cyan"
-	}
-}
-
-func getN8nURLForDashboard() string {
-	switch environment {
-	case "development":
-		return "http://localhost:5678"
-	case "staging":
-		return "https://n8n-staging.example.com"
-	case "production":
-		return "https://n8n-prod.example.com"
-	default:
-		return "http://localhost:5678"
 	}
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
+
+	"github.com/pmaojo/n8n-ops/internal/credentials"
 
 	"github.com/pmaojo/n8n-ops/internal/client"
 	"github.com/sirupsen/logrus"
@@ -58,13 +61,16 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create n8n client using environment configuration
-	n8nURL := os.Getenv("N8N_DEV_URL")
+	cm := credentials.NewCredentialManager(environment)
+	n8nURL, apiKey, err := cm.GetN8nCredentials()
+	if err != nil {
+		return fmt.Errorf("failed to load credentials: %w", err)
+	}
 	if n8nURL == "" {
 		n8nURL = "http://localhost:5678"
 	}
-	apiKey := os.Getenv("N8N_DEV_API_KEY")
 	if apiKey == "" {
-		return fmt.Errorf("N8N_DEV_API_KEY environment variable not set")
+		return fmt.Errorf("N8N_%s_API_KEY environment variable not set", strings.ToUpper(environment))
 	}
 
 	n8nClient, err := client.New(n8nURL, apiKey, nil)

--- a/internal/credentials/manager.go
+++ b/internal/credentials/manager.go
@@ -132,6 +132,15 @@ func (cm *CredentialManager) ValidateCredentials(creds *EnvironmentCredentials) 
 	return nil
 }
 
+// GetN8nCredentials returns the n8n URL and API key for the current environment.
+func (cm *CredentialManager) GetN8nCredentials() (string, string, error) {
+	creds, err := cm.GetEnvironmentCredentials()
+	if err != nil {
+		return "", "", err
+	}
+	return creds.N8nURL, creds.N8nAPIKey, nil
+}
+
 // SetCredential stores a credential for the current environment
 func (cm *CredentialManager) SetCredential(key, value string) error {
 	viper.SetConfigFile(cm.ConfigPath)

--- a/internal/utils/env.go
+++ b/internal/utils/env.go
@@ -8,53 +8,6 @@ import (
 	"strings"
 )
 
-// GetN8nCredentials retrieves n8n URL and API key for the specified environment
-// using a cascading approach to check multiple naming conventions
-func GetN8nCredentials(environment string) (apiURL, apiKey string) {
-	envSuffix := strings.ToUpper(environment)
-
-	// Try environment-specific variables first (N8N_DEVELOPMENT_URL, N8N_DEVELOPMENT_API_KEY)
-	apiURL = os.Getenv(fmt.Sprintf("N8N_%s_URL", envSuffix))
-	apiKey = os.Getenv(fmt.Sprintf("N8N_%s_API_KEY", envSuffix))
-
-	// Fallback to short forms for common environments
-	if apiURL == "" || apiKey == "" {
-		switch environment {
-		case "development":
-			if apiURL == "" {
-				apiURL = os.Getenv("N8N_DEV_URL")
-			}
-			if apiKey == "" {
-				apiKey = os.Getenv("N8N_DEV_API_KEY")
-			}
-		case "staging":
-			if apiURL == "" {
-				apiURL = os.Getenv("N8N_STAGING_URL")
-			}
-			if apiKey == "" {
-				apiKey = os.Getenv("N8N_STAGING_API_KEY")
-			}
-		case "production":
-			if apiURL == "" {
-				apiURL = os.Getenv("N8N_PROD_URL")
-			}
-			if apiKey == "" {
-				apiKey = os.Getenv("N8N_PROD_API_KEY")
-			}
-		}
-	}
-
-	// Final fallback to generic variables (for backward compatibility)
-	if apiURL == "" {
-		apiURL = os.Getenv("N8N_URL")
-	}
-	if apiKey == "" {
-		apiKey = os.Getenv("N8N_API_KEY")
-	}
-
-	return apiURL, apiKey
-}
-
 // GetGitLabCredentials retrieves GitLab token and project ID
 func GetGitLabCredentials(environment string) (token, projectID string) {
 	envSuffix := strings.ToUpper(environment)
@@ -75,28 +28,6 @@ func GetGitLabCredentials(environment string) (token, projectID string) {
 	}
 
 	return token, projectID
-}
-
-// CheckN8nCredentials returns error message if credentials are missing
-func CheckN8nCredentials(environment string) error {
-	apiURL, apiKey := GetN8nCredentials(environment)
-
-	if apiURL == "" || apiKey == "" {
-		envSuffix := strings.ToUpper(environment)
-		return fmt.Errorf(`n8n credentials not configured for %s environment
-
-Set environment variables:
-  export N8N_%s_URL=http://localhost:3001
-  export N8N_%s_API_KEY=your_api_key_here
-
-Or use short forms:
-  export N8N_DEV_URL=http://localhost:3001  (for development)
-  export N8N_DEV_API_KEY=your_api_key_here
-
-Or use --demo flag for testing`, environment, envSuffix, envSuffix)
-	}
-
-	return nil
 }
 
 // LoadEnvFile loads environment variables from a .env file


### PR DESCRIPTION
## Summary
- remove environment-based helper
- add `GetN8nCredentials` to `CredentialManager`
- use `CredentialManager` in commands for n8n API access
- drop unused `getN8nURL` helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880eaf861008333838395ac3e350f9a