### PR TITLE
Fix newline in Makefile output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ ci-test:
 	./n8n-ops validate ./workflows/ --verbose
 	./n8n-ops --help
 	./n8n-ops welcome
-	@echo "CI simulation completed successfully"
+       @echo -e "CI simulation completed successfully\n"


### PR DESCRIPTION
## Summary
- ensure the CI simulation message ends with a newline

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880eb04ac048333ac490b5dd248f9bc