### PR TITLE
Return error from HashWorkflow

### DIFF
--- a/internal/utils/filesystem.go
+++ b/internal/utils/filesystem.go
@@ -132,8 +132,9 @@ func LoadJSONFile(filepath string, v interface{}) error {
 	return nil
 }
 
-// HashWorkflow generates a hash of the workflow for change detection
-func HashWorkflow(wf *workflow.Workflow) string {
+// HashWorkflow generates a deterministic hash of a workflow for change detection.
+// It returns an error if the workflow cannot be marshaled to JSON.
+func HashWorkflow(wf *workflow.Workflow) (string, error) {
 	// Create a copy without sync metadata for consistent hashing
 	wfCopy := *wf
 	wfCopy.SyncMetadata = nil
@@ -141,14 +142,13 @@ func HashWorkflow(wf *workflow.Workflow) string {
 	// Marshal to JSON
 	data, err := json.Marshal(wfCopy)
 	if err != nil {
-		// Fallback to simple hash if marshaling fails
-		return fmt.Sprintf("error_%d", time.Now().Unix())
+		return "", fmt.Errorf("failed to marshal workflow: %w", err)
 	}
 
 	// Generate SHA256 hash
 	hasher := sha256.New()
 	hasher.Write(data)
-	return hex.EncodeToString(hasher.Sum(nil))
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 // BackupFile creates a backup of a file with timestamp

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/pmaojo/n8n-ops/internal/workflow"
 	"path/filepath"
 	"testing"
 )
@@ -59,5 +60,41 @@ func TestEnvironmentHelpers(t *testing.T) {
 		if env == "" {
 			t.Error("Environment name should not be empty")
 		}
+	}
+}
+
+func TestHashWorkflow(t *testing.T) {
+	wf := &workflow.Workflow{
+		ID:    "test123",
+		Name:  "Test Workflow",
+		Nodes: []workflow.Node{},
+	}
+
+	hash, err := HashWorkflow(wf)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if hash == "" {
+		t.Error("hash should not be empty")
+	}
+
+	invalid := &workflow.Workflow{
+		ID:   "bad123",
+		Name: "Bad Workflow",
+		Nodes: []workflow.Node{
+			{
+				ID:       "1",
+				Name:     "bad",
+				Type:     "bad",
+				Position: []float64{0, 0},
+				Parameters: map[string]interface{}{
+					"bad": func() {},
+				},
+			},
+		},
+	}
+
+	if _, err := HashWorkflow(invalid); err == nil {
+		t.Error("expected error for invalid workflow")
 	}
 }


### PR DESCRIPTION
## Summary
- return errors from `HashWorkflow` instead of embedding timestamps
- add a test validating the new behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880eaff785c8333ba1196165adcda96