### PR TITLE
Fix tests by adding n8n credential check

### DIFF
--- a/internal/utils/n8n.go
+++ b/internal/utils/n8n.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// CheckN8nCredentials ensures that the base URL and API key for n8n are present
+// either as generic environment variables (N8N_URL, N8N_API_KEY) or as
+// environment-specific ones (N8N_<ENV>_URL, N8N_<ENV>_API_KEY).
+func CheckN8nCredentials(environment string) error {
+	envSuffix := strings.ToUpper(environment)
+
+	url := os.Getenv(fmt.Sprintf("N8N_%s_URL", envSuffix))
+	if url == "" {
+		url = os.Getenv("N8N_URL")
+	}
+
+	apiKey := os.Getenv(fmt.Sprintf("N8N_%s_API_KEY", envSuffix))
+	if apiKey == "" {
+		apiKey = os.Getenv("N8N_API_KEY")
+	}
+
+	missing := []string{}
+	if url == "" {
+		missing = append(missing, "n8n_url")
+	}
+	if apiKey == "" {
+		missing = append(missing, "n8n_api_key")
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required credentials for %s environment: %s", environment, strings.Join(missing, ", "))
+	}
+
+	return nil
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/pmaojo/n8n-ops/internal/workflow"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"


### PR DESCRIPTION
## Summary
- add a utility to check for required n8n credentials
- import `os` in utils tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880ef0c9d248333ac2302b2153093d3