### PR TITLE
Refactor CaptureWorkflowFailure parameter

### DIFF
--- a/internal/client/n8n_test.go
+++ b/internal/client/n8n_test.go
@@ -156,6 +156,9 @@ func TestCreateWorkflow(t *testing.T) {
 
 	// Test with valid workflow (will timeout, but tests signature)
 	result, err = client.CreateWorkflow(ctx, wf)
+	if err == nil {
+		t.Errorf("expected error due to timeout")
+	}
 
 	// We expect an error due to timeout, but method should exist
 	var _ *workflow.Workflow = result // This should compile

--- a/internal/git/providers/github.go
+++ b/internal/git/providers/github.go
@@ -652,7 +652,7 @@ func (g *GitHubProvider) TriggerPipeline(repoID, branch string) (*Pipeline, erro
 
 	// GitHub doesn't have direct pipeline triggering like GitLab
 	// This would require workflow dispatch events
-	return nil, fmt.Errorf("GitHub pipeline triggering requires workflow_dispatch configuration")
+	return nil, fmt.Errorf("GitHub pipeline triggering for repo %s requires workflow_dispatch configuration", repoID)
 }
 
 // CreatePullRequest creates a pull request in GitHub

--- a/internal/observability/sentry.go
+++ b/internal/observability/sentry.go
@@ -47,11 +47,11 @@ func (s *SentryIntegration) Initialize() error {
 }
 
 // CaptureWorkflowFailure reports workflow failures to Sentry (mock)
-func (s *SentryIntegration) CaptureWorkflowFailure(workflowID, workflowName, error string, ctx context.Context) {
+func (s *SentryIntegration) CaptureWorkflowFailure(workflowID, workflowName, errMsg string, ctx context.Context) {
 	s.logger.WithFields(logrus.Fields{
 		"workflow_id":   workflowID,
 		"workflow_name": workflowName,
-		"error":         error,
+		"error":         errMsg,
 		"environment":   s.config.Environment,
 	}).Info("Workflow failure captured in Sentry (mock)")
 }


### PR DESCRIPTION
## Summary
- rename `error` parameter in `CaptureWorkflowFailure` to `errMsg`
- incorporate repo ID in GitHub provider error message
- check error when creating workflow in tests

## Testing
- `golangci-lint run --fast-only`

------
https://chatgpt.com/codex/tasks/task_e_6880f4b5c9388333b2f5cd429f518af7