### PR TITLE
Improve log file handling

### DIFF
--- a/internal/utils/logger.go
+++ b/internal/utils/logger.go
@@ -9,7 +9,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var globalLogger *logrus.Logger
+var (
+	globalLogger  *logrus.Logger
+	logFileHandle *os.File
+)
 
 // NewLogger creates and configures a new logger instance
 func NewLogger() *logrus.Logger {
@@ -93,16 +96,33 @@ func SetLogFile(filename string) error {
 		return err
 	}
 
+	// Close previously opened file to avoid descriptor leaks
+	if logFileHandle != nil {
+		_ = logFileHandle.Close()
+		logFileHandle = nil
+	}
+
 	// Open log file
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		return err
 	}
+	logFileHandle = file
 
 	// Set output to both file and stdout
 	multiWriter := io.MultiWriter(os.Stdout, file)
 	globalLogger.SetOutput(multiWriter)
 
+	return nil
+}
+
+// CloseLogFile closes the active log file if one is open
+func CloseLogFile() error {
+	if logFileHandle != nil {
+		err := logFileHandle.Close()
+		logFileHandle = nil
+		return err
+	}
 	return nil
 }
 
@@ -134,6 +154,8 @@ func configureLogger(logger *logrus.Logger) {
 	// Check for log file in environment
 	if logFile := os.Getenv("LOG_FILE"); logFile != "" {
 		SetLogFile(logFile)
+	} else {
+		CloseLogFile()
 	}
 }
 

--- a/internal/utils/logger_test.go
+++ b/internal/utils/logger_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func countOpenFDsFor(path string) (int, error) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, e := range entries {
+		link, err := os.Readlink(filepath.Join("/proc/self/fd", e.Name()))
+		if err != nil {
+			continue
+		}
+		if link == path {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func TestSetLogFileClosesPrevious(t *testing.T) {
+	if _, err := os.Stat("/proc/self/fd"); err != nil {
+		t.Skip("proc filesystem not available")
+	}
+
+	dir := t.TempDir()
+	file1 := filepath.Join(dir, "first.log")
+	file2 := filepath.Join(dir, "second.log")
+
+	if err := SetLogFile(file1); err != nil {
+		t.Fatalf("set first log file: %v", err)
+	}
+	c, err := countOpenFDsFor(file1)
+	if err != nil || c != 1 {
+		t.Fatalf("expected 1 open fd for first file, got %d (err=%v)", c, err)
+	}
+
+	if err := SetLogFile(file2); err != nil {
+		t.Fatalf("set second log file: %v", err)
+	}
+	c1, _ := countOpenFDsFor(file1)
+	if c1 != 0 {
+		t.Fatalf("first log file descriptor should be closed, got %d", c1)
+	}
+	c2, _ := countOpenFDsFor(file2)
+	if c2 != 1 {
+		t.Fatalf("expected 1 open fd for second file, got %d", c2)
+	}
+
+	if err := CloseLogFile(); err != nil {
+		t.Fatalf("close second log file: %v", err)
+	}
+	c2After, _ := countOpenFDsFor(file2)
+	if c2After != 0 {
+		t.Fatalf("log file should be closed after CloseLogFile, got %d", c2After)
+	}
+}


### PR DESCRIPTION
## Summary
- manage log file lifecycle via a global handle
- close old log file before opening a new one
- add `CloseLogFile` helper
- test that `SetLogFile` does not leak descriptors

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880f4c251f88333816c187fb4e8d33f