### PR TITLE
Add modular validation helpers for git-send-email

### DIFF
--- a/hooks/sendemail-validate.sample
+++ b/hooks/sendemail-validate.sample
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# An example hook script to validate a patch (and/or patch series) before
+# sending it via email.
+#
+# The hook should exit with non-zero status after issuing an appropriate
+# message if it wants to prevent the email(s) from being sent.
+#
+# To enable this hook, rename this file to "sendemail-validate".
+#
+# By default, it will only check that the patch(es) can be applied on top of
+# the default upstream branch without conflicts in a secondary worktree. After
+# validation (successful or not) of the last patch of a series, the worktree
+# will be deleted.
+#
+# The following config variables can be set to change the default remote and
+# remote ref that are used to apply the patches against:
+#
+#   sendemail.validateRemote (default: origin)
+#   sendemail.validateRemoteRef (default: HEAD)
+#
+# Load modular validation helpers. Override HOOK_HELPERS_PATH to use a
+# different set of helper functions.
+HOOK_HELPERS_PATH=${HOOK_HELPERS_PATH:-"$(git rev-parse --show-toplevel)/scripts/hook_checks.sh"}
+[ -f "$HOOK_HELPERS_PATH" ] && . "$HOOK_HELPERS_PATH"
+
+validate_cover_letter () {
+        file="$1"
+        spell_check "$file"
+}
+
+validate_patch () {
+        file="$1"
+        # Ensure that the patch applies without conflicts.
+        git am -3 "$file" || return
+        style_check "$file"
+        lint_check "$file"
+}
+
+validate_series () {
+        build_check
+}
+
+# main -------------------------------------------------------------------------
+
+if test "$GIT_SENDEMAIL_FILE_COUNTER" = 1
+then
+	remote=$(git config --default origin --get sendemail.validateRemote) &&
+	ref=$(git config --default HEAD --get sendemail.validateRemoteRef) &&
+	worktree=$(mktemp --tmpdir -d sendemail-validate.XXXXXXX) &&
+	git worktree add -fd --checkout "$worktree" "refs/remotes/$remote/$ref" &&
+	git config --replace-all sendemail.validateWorktree "$worktree"
+else
+	worktree=$(git config --get sendemail.validateWorktree)
+fi || {
+	echo "sendemail-validate: error: failed to prepare worktree" >&2
+	exit 1
+}
+
+unset GIT_DIR GIT_WORK_TREE
+cd "$worktree" &&
+
+if grep -q "^diff --git " "$1"
+then
+	validate_patch "$1"
+else
+	validate_cover_letter "$1"
+fi &&
+
+if test "$GIT_SENDEMAIL_FILE_COUNTER" = "$GIT_SENDEMAIL_FILE_TOTAL"
+then
+	git config --unset-all sendemail.validateWorktree &&
+	trap 'git worktree remove -ff "$worktree"' EXIT &&
+	validate_series
+fi
+

--- a/scripts/hook_checks.sh
+++ b/scripts/hook_checks.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Helper script with modular validation functions for git-send-email hook.
+# Each check can be customized by setting the corresponding environment
+# variable. When a command is undefined or unavailable, the check is skipped
+# gracefully. This design avoids strong coupling to specific external tools
+# and makes the checks easily testable in isolation.
+
+run_cmd() {
+    cmd="$1"
+    shift
+    if [ -n "$cmd" ] && command -v "${cmd%% *}" >/dev/null 2>&1; then
+        eval "$cmd" "$@"
+    else
+        # Skip silently when command is not provided or not found
+        return 0
+    fi
+}
+
+spell_check() {
+    run_cmd "${SPELL_CHECK_CMD:-}" "$@"
+}
+
+style_check() {
+    run_cmd "${STYLE_CHECK_CMD:-}" "$@"
+}
+
+lint_check() {
+    run_cmd "${LINT_CHECK_CMD:-}" "$@"
+}
+
+build_check() {
+    run_cmd "${BUILD_CHECK_CMD:-}" "$@"
+}
+


### PR DESCRIPTION
## Summary
- add `scripts/hook_checks.sh` with reusable validation helpers
- add `hooks/sendemail-validate.sample` and replace TODOs with helper calls

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6880fa394ed083338a20bb3af503e82c