### PR TITLE
Introduce DashboardService for UI

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"time"
 
+	"github.com/pmaojo/n8n-ops/internal/dashboard"
 	"github.com/spf13/cobra"
 )
 
@@ -50,70 +50,15 @@ func runUI(cmd *cobra.Command, args []string) error {
 		fmt.Printf("🌐 Opening browser...\n")
 	}
 
-	// Create a simple UI server
-	return startUIServer(environment, uiPort)
+	// Create a simple UI server using the demo dashboard service
+	svc := dashboard.NewDemoService()
+	return startUIServer(environment, uiPort, svc)
 }
 
-func startUIServer(env string, port int) error {
-	// Check for real uncommitted workflow changes (remove demo simulation)
-	hasRealUncommittedChanges := false
-	realUncommittedWorkflows := []struct {
-		WorkflowName string
-		Status       string
-		Environment  string
-		FilePath     string
-	}{}
-
-	// For now, show clean state until real Git integration is implemented
-	// In production, this would check actual Git status
-
-	// Simple dashboard data
-	dashboardData := struct {
-		Environment string
-		Status      string
-		Workflows   []struct {
-			Name   string
-			Status string
-			Branch string
-		}
-		Credentials []struct {
-			Name   string
-			Status string
-		}
-		LastSync              time.Time
-		HasUncommittedChanges bool
-		UncommittedWorkflows  []struct {
-			WorkflowName string
-			Status       string
-			Environment  string
-			FilePath     string
-		}
-		GitBranch string
-	}{
-		Environment:           env,
-		Status:                "connected",
-		LastSync:              time.Now(),
-		HasUncommittedChanges: hasRealUncommittedChanges,
-		UncommittedWorkflows:  realUncommittedWorkflows,
-		GitBranch:             "main", // Default branch
-		Workflows: []struct {
-			Name   string
-			Status string
-			Branch string
-		}{
-			{"Customer Onboarding Process", "active", "main"},
-			{"Email Notification System", "active", "main"},
-			{"Payment Processing", "active", "main"},
-		},
-		Credentials: []struct {
-			Name   string
-			Status string
-		}{
-			{"N8N API", "missing"},
-			{"SMTP", "missing"},
-			{"PostgreSQL", "missing"},
-			{"Stripe", "missing"},
-		},
+func startUIServer(env string, port int, svc dashboard.Service) error {
+	dashboardData, err := svc.GetDashboardData(env)
+	if err != nil {
+		return err
 	}
 
 	// Simple HTML template

--- a/internal/dashboard/demo_service.go
+++ b/internal/dashboard/demo_service.go
@@ -1,0 +1,37 @@
+package dashboard
+
+import "time"
+
+// DemoService provides hard-coded dashboard data for demo purposes.
+type DemoService struct{}
+
+// NewDemoService returns a new DemoService.
+func NewDemoService() *DemoService {
+	return &DemoService{}
+}
+
+// GetDashboardData returns static data used for the demo dashboard.
+func (d *DemoService) GetDashboardData(env string) (Data, error) {
+	// In the future, replace with real implementations.
+	data := Data{
+		Environment: env,
+		Status:      "connected",
+		LastSync:    time.Now(),
+		GitBranch:   "main",
+		Workflows: []Workflow{
+			{Name: "Customer Onboarding Process", Status: "active", Branch: "main"},
+			{Name: "Email Notification System", Status: "active", Branch: "main"},
+			{Name: "Payment Processing", Status: "active", Branch: "main"},
+		},
+		Credentials: []Credential{
+			{Name: "N8N API", Status: "missing"},
+			{Name: "SMTP", Status: "missing"},
+			{Name: "PostgreSQL", Status: "missing"},
+			{Name: "Stripe", Status: "missing"},
+		},
+		HasUncommittedChanges: false,
+		UncommittedWorkflows:  nil,
+	}
+
+	return data, nil
+}

--- a/internal/dashboard/demo_service_test.go
+++ b/internal/dashboard/demo_service_test.go
@@ -1,0 +1,17 @@
+package dashboard
+
+import "testing"
+
+func TestDemoServiceReturnsData(t *testing.T) {
+	svc := NewDemoService()
+	data, err := svc.GetDashboardData("dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.Environment != "dev" {
+		t.Errorf("expected environment dev, got %s", data.Environment)
+	}
+	if len(data.Workflows) == 0 {
+		t.Error("expected demo workflows")
+	}
+}

--- a/internal/dashboard/service.go
+++ b/internal/dashboard/service.go
@@ -1,0 +1,41 @@
+package dashboard
+
+import "time"
+
+// Workflow holds minimal workflow info for the dashboard.
+type Workflow struct {
+	Name   string
+	Status string
+	Branch string
+}
+
+// Credential holds credential status info for the dashboard.
+type Credential struct {
+	Name   string
+	Status string
+}
+
+// UncommittedWorkflow represents a workflow with local changes.
+type UncommittedWorkflow struct {
+	WorkflowName string
+	Status       string
+	Environment  string
+	FilePath     string
+}
+
+// Data aggregates dashboard information.
+type Data struct {
+	Environment           string
+	Status                string
+	Workflows             []Workflow
+	Credentials           []Credential
+	LastSync              time.Time
+	HasUncommittedChanges bool
+	UncommittedWorkflows  []UncommittedWorkflow
+	GitBranch             string
+}
+
+// Service defines the behavior required to obtain dashboard data.
+type Service interface {
+	GetDashboardData(env string) (Data, error)
+}


### PR DESCRIPTION
## Summary
- abstract dashboard data via `DashboardService`
- add demo implementation returning static data
- inject service into `startUIServer`
- cover demo service with unit test

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68811280c3308333a5365308f87c8d98