### PR TITLE
Fix logging config access

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,16 @@ type LoggingConfig struct {
 	File   string `mapstructure:"file"`
 }
 
+// GetLoggingConfig returns the logging configuration from the Config instance.
+// It does not modify the state of the Config and adheres to the principle of
+// providing read-only access to configuration values.
+func (c *Config) GetLoggingConfig() *LoggingConfig {
+	if c == nil {
+		return &LoggingConfig{}
+	}
+	return &c.Logging
+}
+
 // NewConfig creates and initializes a new Config object
 func NewConfig() (*Config, error) {
 	config := &Config{}
@@ -96,6 +106,18 @@ func GetConfig() *Config {
 	return globalConfig
 }
 
+// InitConfig initializes the global configuration instance using values loaded
+// in Viper. It allows tests and other packages to easily set up configuration
+// without relying on command initialization logic.
+func InitConfig() error {
+	cfg, err := NewConfig()
+	if err != nil {
+		return err
+	}
+	globalConfig = cfg
+	return nil
+}
+
 // GetEnvironmentConfig returns configuration for a specific environment
 func GetEnvironmentConfig(environment string) (*EnvironmentConfig, error) {
 	config := GetConfig()
@@ -140,5 +162,5 @@ func IsAutoBackupEnabled() bool {
 // GetLoggingConfig returns the logging configuration
 func GetLoggingConfig() *LoggingConfig {
 	config := GetConfig()
-	return &config.Logging
+	return config.GetLoggingConfig()
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,7 +37,9 @@ func TestInitConfigLoadsConfiguration(t *testing.T) {
 	prepareConfig(cfgYAML)
 	t.Setenv("TEST_KEY", "secret")
 
-	InitConfig()
+	if err := InitConfig(); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
 
 	cfg := GetConfig()
 	if cfg.Defaults.Environment != "test" {
@@ -64,7 +66,9 @@ func TestInitConfigLoadsConfiguration(t *testing.T) {
 
 func TestGetEnvironmentConfigErrors(t *testing.T) {
 	prepareConfig("environments: {}")
-	InitConfig()
+	if err := InitConfig(); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
 	if _, err := GetEnvironmentConfig("missing"); err == nil {
 		t.Error("expected error for unknown environment")
 	}

--- a/internal/utils/logger_test.go
+++ b/internal/utils/logger_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func countOpenFDsFor(path string) (int, error) {
@@ -33,7 +35,9 @@ func TestSetLogFileClosesPrevious(t *testing.T) {
 	file1 := filepath.Join(dir, "first.log")
 	file2 := filepath.Join(dir, "second.log")
 
-	if err := SetLogFile(file1); err != nil {
+	logger := logrus.New()
+
+	if err := SetLogFile(logger, file1); err != nil {
 		t.Fatalf("set first log file: %v", err)
 	}
 	c, err := countOpenFDsFor(file1)
@@ -41,7 +45,7 @@ func TestSetLogFileClosesPrevious(t *testing.T) {
 		t.Fatalf("expected 1 open fd for first file, got %d (err=%v)", c, err)
 	}
 
-	if err := SetLogFile(file2); err != nil {
+	if err := SetLogFile(logger, file2); err != nil {
 		t.Fatalf("set second log file: %v", err)
 	}
 	c1, _ := countOpenFDsFor(file1)


### PR DESCRIPTION
## Summary
- add `GetLoggingConfig` method on `Config`
- expose `InitConfig` helper for tests
- update logger tests to use new signature
- adjust config tests for new helper

## Testing
- `go test ./...` *(fails: `integration` tests interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68814e2cb7cc8333a661dfd8c6bbc4e9