### PR TITLE
Fix summary counts in daemon tests

### DIFF
--- a/tests/daemon_test.go
+++ b/tests/daemon_test.go
@@ -441,17 +441,22 @@ func TestDaemonCompleteValidation(t *testing.T) {
 	failed := 0
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		test := test
+		success := t.Run(test.name, func(t *testing.T) {
 			defer func() {
 				if r := recover(); r != nil {
 					t.Errorf("❌ Test %s falló con panic: %v", test.name, r)
-					failed++
 				}
 			}()
 
 			test.testFunc(t)
-			passed++
 		})
+
+		if success {
+			passed++
+		} else {
+			failed++
+		}
 	}
 
 	t.Log("=" + strings.Repeat("=", 50))
@@ -459,5 +464,7 @@ func TestDaemonCompleteValidation(t *testing.T) {
 
 	if failed == 0 {
 		t.Log("🎉 ¡TODOS LOS TESTS PASARON! EL DAEMON FUNCIONA PERFECTAMENTE")
+	} else {
+		t.Fail()
 	}
 }


### PR DESCRIPTION
## Summary
- increment `passed` counter only when subtests succeed
- mark the test as failed when any subtests fail

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6881532ed8a0833399bada2783fbafd1