### PR TITLE
Refactor daemon client setup to use CLI utils

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/pmaojo/n8n-ops/internal/client"
+	"github.com/pmaojo/n8n-ops/internal/cliutils"
+	"github.com/pmaojo/n8n-ops/internal/credentials"
 	"github.com/pmaojo/n8n-ops/internal/i18n"
 	"github.com/pmaojo/n8n-ops/internal/workflow"
 	"github.com/sirupsen/logrus"
@@ -49,8 +51,8 @@ var daemonWatcherFactory = func() (fileWatcher, error) {
 	return &fsnotifyWatcher{w}, nil
 }
 
-var daemonClientFactory = func(url string) (client.Client, error) {
-	return client.New(url, "n8n_api_mock_development", nil)
+var daemonClientSetup = func(env string, demo bool, logger logrus.FieldLogger) (client.Client, *credentials.CredentialManager, error) {
+	return cliutils.SetupClient(env, demo, logger)
 }
 
 // runDaemonMode starts the file watcher and synchronizes workflow changes with n8n.
@@ -72,25 +74,7 @@ func runDaemonModeCtx(ctx context.Context, env string) {
 	i18n.PrintfKey("daemon_watching_files", env)
 	i18n.PrintlnKey("daemon_creating_backups")
 
-	// Create n8n client with proper URL for demo mode
-	var n8nURL string
-	if demoMode {
-		n8nURL = "http://localhost:3001"
-	} else {
-		// Use environment-specific URL from config
-		switch env {
-		case "development":
-			n8nURL = "http://localhost:5678"
-		case "staging":
-			n8nURL = "https://n8n-staging.example.com"
-		case "production":
-			n8nURL = "https://n8n-prod.example.com"
-		default:
-			n8nURL = "http://localhost:5678"
-		}
-	}
-
-	n8nClient, err := daemonClientFactory(n8nURL)
+	n8nClient, _, err := daemonClientSetup(env, demoMode, logEntry)
 	if err != nil {
 		logEntry.WithError(err).Fatal("Failed to create n8n client")
 		return

--- a/cmd/daemon_mode_test.go
+++ b/cmd/daemon_mode_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/pmaojo/n8n-ops/internal/client"
+	"github.com/pmaojo/n8n-ops/internal/cliutils"
 	"github.com/pmaojo/n8n-ops/internal/credentials"
 	"github.com/pmaojo/n8n-ops/internal/workflow"
 	"github.com/sirupsen/logrus"
@@ -86,8 +88,17 @@ func TestRunDaemonModeCtxProcessesEvent(t *testing.T) {
 	mw := &mockWatcher{events: make(chan fsnotify.Event, 1), errs: make(chan error)}
 	mc := &mockClient{}
 
+	originalWatcherFactory := daemonWatcherFactory
+	originalClientSetup := daemonClientSetup
+	t.Cleanup(func() {
+		daemonWatcherFactory = originalWatcherFactory
+		daemonClientSetup = originalClientSetup
+	})
+
 	daemonWatcherFactory = func() (fileWatcher, error) { return mw, nil }
-	daemonClientFactory = func(string) (client.Client, error) { return mc, nil }
+	daemonClientSetup = func(string, bool, logrus.FieldLogger) (client.Client, *credentials.CredentialManager, error) {
+		return mc, nil, nil
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go runDaemonModeCtx(ctx, env)
@@ -98,4 +109,36 @@ func TestRunDaemonModeCtxProcessesEvent(t *testing.T) {
 
 	assert.True(t, mc.healthCalled)
 	assert.True(t, mc.updateCalled)
+}
+
+func TestRunDaemonModeCtxMissingCredentials(t *testing.T) {
+	logger = logrus.New()
+	exitCalled := false
+	logger.ExitFunc = func(int) { exitCalled = true }
+
+	originalDemoMode := demoMode
+	demoMode = false
+	t.Cleanup(func() { demoMode = originalDemoMode })
+
+	originalWatcherFactory := daemonWatcherFactory
+	originalClientSetup := daemonClientSetup
+	t.Cleanup(func() {
+		daemonWatcherFactory = originalWatcherFactory
+		daemonClientSetup = originalClientSetup
+	})
+
+	watcherInvoked := false
+	daemonWatcherFactory = func() (fileWatcher, error) {
+		watcherInvoked = true
+		return nil, errors.New("should not be called when credentials are missing")
+	}
+
+	daemonClientSetup = func(env string, demo bool, log logrus.FieldLogger) (client.Client, *credentials.CredentialManager, error) {
+		return nil, nil, cliutils.MissingCredentialError{Missing: []string{"n8n_url"}}
+	}
+
+	runDaemonModeCtx(context.Background(), "dev")
+
+	assert.True(t, exitCalled)
+	assert.False(t, watcherInvoked)
 }


### PR DESCRIPTION
## Summary
- initialize the daemon client through `cliutils.SetupClient` so environment credentials are respected
- update daemon mode to rely on the injected setup helper while keeping test seams
- extend daemon tests to cover successful runs and missing credential errors

## Testing
- `go test ./cmd -run TestRunDaemonModeCtx -count=1 -v`
- `go test ./...` *(fails: internal/observability TestGrafanaIntegrationSendWorkflowMetrics: metrics not sent)*

------
https://chatgpt.com/codex/tasks/task_e_69077cea4c3083338b0c0fae6c10b928